### PR TITLE
Update config for Debian Stretch.

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -7,15 +7,12 @@ Port 22
 #ListenAddress ::
 #ListenAddress 0.0.0.0
 Protocol 2
-# HostKeys for protocol version 2
-HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
+# HostKeys
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security
 UsePrivilegeSeparation yes
-
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 3600
-ServerKeyBits 768
 
 # Logging
 SyslogFacility AUTH
@@ -26,15 +23,12 @@ LoginGraceTime 120
 PermitRootLogin without-password
 StrictModes yes
 
-RSAAuthentication yes
 PubkeyAuthentication yes
 AuthorizedKeysFile	%h/.ssh/authorized_keys
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
 # For this to work you will also need host keys in /etc/ssh_known_hosts
-RhostsRSAAuthentication no
-# similar for protocol version 2
 HostbasedAuthentication no
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
 #IgnoreUserKnownHosts yes


### PR DESCRIPTION
Remove deprecated options KeyRegenerationInterval, ServerKeyBits,
RSAAuthentication, RhostsRSAAuthentication.
Remove HostKey path for nonexistent dsa key.