### PR TITLE
Update config for Debian Buster

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -11,8 +11,6 @@ Protocol 2
 #HostKey /etc/ssh/ssh_host_rsa_key
 #HostKey /etc/ssh/ssh_host_ecdsa_key
 #HostKey /etc/ssh/ssh_host_ed25519_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
 
 # Logging
 SyslogFacility AUTH


### PR DESCRIPTION
Remove deprecated UsePrivilegeSeparation since it has been enabled
mandatorily since OpenSSH 7.5. https://www.openssh.com/txt/release-7.5