### PR TITLE
Allow usage of deprecated ssh-rsa key algorithm and remove ssh package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,6 @@
 - name: Install openssh packages
   apt:
     name: 
-      - ssh
       - openssh-client
       - openssh-server
   notify:

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -22,6 +22,7 @@ PermitRootLogin without-password
 StrictModes yes
 
 PubkeyAuthentication yes
+PubkeyAcceptedAlgorithms=+ssh-rsa
 AuthorizedKeysFile	%h/.ssh/authorized_keys
 
 # Don't read the user's ~/.rhosts and ~/.shosts files


### PR DESCRIPTION
Allow usage of deprecated ssh-rsa key algorithm that is disabled by default on newer openssh versions until all the keys are migrated to a newer algorithm and remove the ssh package from the list of installed packages as it is unnecessary.