### PR TITLE
Fix deprecated syntax for compability with newer Ansible versions

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 # handlers file for ajsalminen.sshd
 
-- include: openssh.yml
+- import_tasks: openssh.yml

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -22,7 +22,9 @@ PermitRootLogin without-password
 StrictModes yes
 
 PubkeyAuthentication yes
+{% if ansible_distribution == 'Debian' and ansible_distribution_major_version | int > 11 %}
 PubkeyAcceptedAlgorithms=+ssh-rsa
+{% endif %}
 AuthorizedKeysFile	%h/.ssh/authorized_keys
 
 # Don't read the user's ~/.rhosts and ~/.shosts files


### PR DESCRIPTION
Changes include in main.yml of handlers to import_tasks and fixes PubkeyAcceptedAlgorithms to PubkeyAcceptedKeyTypes in a template. The template was changed as the previous variable caused the config to not work with newer versions of sshd.